### PR TITLE
Add CI workflow and smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Lint
+        run: flake8 . --exit-zero
+      - name: Test
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flake8
+pytest

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _python_subprojects():
+    for path in ROOT.iterdir():
+        if path.name.startswith('.') or path.name in {"bin", "tests"}:
+            continue
+        if path.is_dir() and any(
+            p.suffix == '.py' for p in path.rglob('*.py')
+        ):
+            yield path
+
+
+@pytest.mark.parametrize(
+    "subproject", list(_python_subprojects())
+)
+def test_subproject_smoke(subproject):
+    for py_file in subproject.rglob('*.py'):
+        try:
+            compile(
+                py_file.read_text(encoding='utf-8', errors='ignore'),
+                str(py_file),
+                'exec',
+            )
+        except SyntaxError as exc:  # pragma: no cover - smoke test
+            pytest.xfail(f"Syntax error in {py_file}: {exc}")
+
+
+@pytest.mark.parametrize('py_file', list(ROOT.glob('*.py')))
+def test_root_python_files(py_file):
+    try:
+        compile(
+            py_file.read_text(encoding='utf-8', errors='ignore'),
+            str(py_file),
+            'exec',
+        )
+    except SyntaxError as exc:  # pragma: no cover - smoke test
+        pytest.xfail(f"Syntax error in {py_file}: {exc}")

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -26,7 +26,7 @@ def test_subproject_smoke(subproject):
                 'exec',
             )
         except SyntaxError as exc:  # pragma: no cover - smoke test
-            pytest.xfail(f"Syntax error in {py_file}: {exc}")
+            pytest.fail(f"Syntax error in {py_file}: {exc}")
 
 
 @pytest.mark.parametrize('py_file', list(ROOT.glob('*.py')))
@@ -38,4 +38,4 @@ def test_root_python_files(py_file):
             'exec',
         )
     except SyntaxError as exc:  # pragma: no cover - smoke test
-        pytest.xfail(f"Syntax error in {py_file}: {exc}")
+        pytest.fail(f"Syntax error in {py_file}: {exc}")


### PR DESCRIPTION
## Summary
- run pip install, flake8, and pytest in CI
- add repo-wide smoke tests to compile every Python file
- declare minimal requirements for linting and testing

## Testing
- `flake8 . --exit-zero`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c79cc130c88327b5c83fb02d885c0f