### PR TITLE
Adjust Moodmancer log path and add README

### DIFF
--- a/Moodmancer/README.md
+++ b/Moodmancer/README.md
@@ -1,0 +1,18 @@
+# Moodmancer
+
+Moodmancer is a playful mood analyzer with a Tkinter GUI.
+
+## Configuration
+
+The first time the script runs it creates `moodmancer_config.json` in the working directory. You can edit this file to customize keywords, colors, and the log file location. By default the log is stored in `~/CHAOS_Logs/mood_log.txt`.
+
+## Runtime dependencies
+
+- Python 3
+- Tkinter (often provided by `python3-tk` on Linux)
+
+Run the app with:
+
+```bash
+python scripts/moodmancer.py
+```

--- a/Moodmancer/scripts/moodmancer.py
+++ b/Moodmancer/scripts/moodmancer.py
@@ -8,6 +8,7 @@ import re
 import random
 import datetime
 from tkinter.font import Font
+from pathlib import Path
 
 class MoodMancerGUI:
     def __init__(self, root):
@@ -52,7 +53,7 @@ class MoodMancerGUI:
                 "background": "#1E1E2E", # Dark background
                 "text": "#FFFFFF"       # White text
             },
-            "log_file": "C:\\EdenOS_Origin\\CHAOS_Logs\\mood_log.txt"
+            "log_file": str((Path.home() / "CHAOS_Logs" / "mood_log.txt").resolve())
 
         }
         


### PR DESCRIPTION
## Summary
- Make log storage portable by resolving `~/CHAOS_Logs/mood_log.txt` with `pathlib.Path`
- Document configuration and dependencies in a new README

## Testing
- `python -m py_compile Moodmancer/scripts/moodmancer.py`


------
https://chatgpt.com/codex/tasks/task_e_68c79cb973108327b8c760d09805a646